### PR TITLE
Refactor build_board method to store a hash in a hash and update boar…

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -7,28 +7,26 @@ class Board
 
   def build_board
     new_board = {}
-    row = 0
-    column = ""
-    key = ""
-    value = []
+    col = ["A", "B", "C", "D", "E", "F", "G"]
 
     #Creates 7 columns
     7.times do |i|
-      column = ["A", "B", "C", "D", "E", "F", "G"]
 
-      #Creates 6 rows
-      6.times do |j|
-        #Determine rows
-        row = j + 1
+        #Creates 6 rows
+        6.times do |j|
+            #Determine row
+            row = j + 1
 
-        #Creates the keys and values for new_board hash
-        key = column[i] + row.to_s
-        value = [i + 1, row, nil]
+            #Creates the key symbol for new_board hash
+            key = col[i] + row.to_s
 
-        #Putting key => value pair into new_board hash
-        new_board[key.to_sym] = value 
-
-      end
+            #Putting key => value pair into new_board hash
+            new_board[key.to_sym] = {
+                column: i+1,
+                row: row,
+                checker: nil
+            }
+        end
     end
     new_board
   end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -19,13 +19,13 @@ describe 'Board' do
       expect(@board.layout.length).to eq(42)
 
       num_columns = @board.layout.select do |key, value|
-        value[1] == 6
+        value[:row] == 6
       end
 
       expect(num_columns.length).to be(7)
 
       num_rows = @board.layout.select do |key, value|
-        value[0] == 3
+        value[:column] == 3
       end
 
       expect(num_rows.length).to be(6)


### PR DESCRIPTION
Substituted the array inside the original hash for a hash.  This allows us to search for :column, :row, or :checker key-value pairs instead of [0], [1], and [2] respectively.  Updated the spec file to account for this change.